### PR TITLE
fix(index): make index_has robust for JSONL streams

### DIFF
--- a/lib/index.sh
+++ b/lib/index.sh
@@ -78,7 +78,9 @@ index_update() {
 # Check if a path exists in the index
 index_has() {
   local target_path="$1"
-  jq -e --arg p "$target_path" 'select(.path == $p)' "$CLAW_DRIVE_INDEX" > /dev/null 2>&1
+  # jq -e can return non-zero with JSONL streams in some envs despite a match;
+  # use exact path membership check for robust existence probing.
+  jq -r '.path // empty' "$CLAW_DRIVE_INDEX" 2>/dev/null | grep -Fxq "$target_path"
 }
 
 # Dedup: remove hash entry for a path (exact match, regex-safe)


### PR DESCRIPTION
## Summary
- rebased on latest `main` (includes PR #3 and PR #4)
- fix `index_has` existence probing for JSONL indexes by switching to exact-path membership check

## Motivation
In this environment (`jq-1.6`), the original command used in `index_has`:

```bash
jq -e --arg p "$target_path" 'select(.path == $p)' "$CLAW_DRIVE_INDEX" > /dev/null
```

can return non-zero even when a matching row exists in JSONL input.

## Concrete reproducer
`jq --version` → `jq-1.6`

```bash
jq -e --arg p 'documents/testfile.txt' 'select(.path == $p)' "$TEST_DIR/INDEX.jsonl" >/dev/null
echo $?
# => 4 (while a matching row exists)
```

and without redirect, the match is printed.

This causes `claw-drive update <path> ...` to fail with `Not found in index` in tests.

## Validation
- Ran full test suite: `bash test/test.sh`
- Result: **62 passed, 0 failed**
